### PR TITLE
Optimize pairings

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 TypeScript reference implementation for the [BBS signature scheme](https://github.com/decentralized-identity/bbs-signature). The goal is to help understand and verify the specification. This is NOT a production-ready implementation; testing is minimal and no effort is made to optimize and protect against specialized attacks (e.g., side-channel resistance). 
 
-This project aims to keep up to date with the [latest specification](https://identity.foundation/bbs-signature/draft-looker-cfrg-bbs-signatures.html), but may be behind since the specification changes often; the current implementation matches the *Sept 26, 2002* version of the specification. 
+This project aims to keep up to date with the [latest specification](https://identity.foundation/bbs-signature/draft-looker-cfrg-bbs-signatures.html), but may be behind since the specification changes often; the current implementation matches the *Sept 26, 2022* version of the specification. 
 
 Given the rapid evolution of the BBS scheme, there might be inconsistencies between the specification and the code; please open issues or file PRs if you find any!
 

--- a/src/bbs.ts
+++ b/src/bbs.ts
@@ -113,9 +113,9 @@ export class BBS {
     }
        
     // check that e(A, W + P2 * e) * e(B, -P2) == Identity_GT
-    const lh = bls.pairing(sig.A, W.add(bls.PointG2.BASE.multiply(sig.e)));
-    const rh = bls.pairing(B, bls.PointG2.BASE.negate());
-    const pairing = lh.multiply(rh);
+    const lh = bls.pairing(sig.A, W.add(bls.PointG2.BASE.multiply(sig.e)), false);
+    const rh = bls.pairing(B, bls.PointG2.BASE.negate(), false);
+    const pairing = lh.multiply(rh).finalExponentiate();
     if (!pairing.equals(bls.Fp12.ONE)) {
       throw "Invalid signature (pairing)";
     }
@@ -251,9 +251,9 @@ export class BBS {
         throw "Invalid proof (A')";
       }
 
-      const lh = bls.pairing(proof_value.APrime, W);
-      const rh = bls.pairing(proof_value.ABar, bls.PointG2.BASE.negate());
-      const pairing = lh.multiply(rh);
+      const lh = bls.pairing(proof_value.APrime, W, false);
+      const rh = bls.pairing(proof_value.ABar, bls.PointG2.BASE.negate(), false);
+      const pairing = lh.multiply(rh).finalExponentiate();
       if (!pairing.equals(bls.Fp12.ONE)) {
         throw "Invalid proof (pairing)"
       }


### PR DESCRIPTION
This PR is to optimize the verification of signatures and proofs by exploiting a property of pairings.

Instead of doing 2 exponentiations, we can do only one final exponentiation after multiplying 2 points calculated by Miller loops.
In this way, we optimize the performance by avoiding one final exponentiation that would take about _14 ms_, according to estimates from the noble-bls12-381 library.

The `pairing` function performs the final exponentiation by default but it's possible to change its behavior by introducing a third input `withFinalExponent = false`.