### PR TITLE
Updated to spec draft-07

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 TypeScript reference implementation for the [BBS signature scheme](https://github.com/decentralized-identity/bbs-signature). The goal is to help understand and verify the specification. This is NOT a production-ready implementation; testing is minimal and no effort is made to optimize and protect against specialized attacks (e.g., side-channel resistance). 
 
-This project aims to keep up to date with the [latest specification](https://identity.foundation/bbs-signature/draft-irtf-cfrg-bbs-signatures.html), but may be behind since the specification changes often; the current implementation matches the *26 June 2024* version of the specification, matching the [draft-irtf-cfrg-bbs-signatures-06](https://datatracker.ietf.org/doc/draft-irtf-cfrg-bbs-signatures/06/) version submitted to the CFRG.
+This project aims to keep up to date with the [latest specification](https://identity.foundation/bbs-signature/draft-irtf-cfrg-bbs-signatures.html), but may be behind since the specification changes often; the current implementation matches the *23 September 2024* version of the specification, matching the [draft-irtf-cfrg-bbs-signatures-07](https://datatracker.ietf.org/doc/draft-irtf-cfrg-bbs-signatures/07/) version submitted to the CFRG.
 
 Given the rapid evolution of the BBS scheme, there might be inconsistencies between the specification and the code; please open issues or file PRs if you find any!
 


### PR DESCRIPTION
Draft 07 of the BBS signature scheme specification was released on September 23, 2024. It only contains editorial changes; no code update required. Test fixtures validate.