### PR TITLE
Reject non-canonical signature and proof encodings

### DIFF
--- a/src/bbs.ts
+++ b/src/bbs.ts
@@ -388,18 +388,23 @@ export class BBS {
 
   // https://identity.foundation/bbs-signature/draft-irtf-cfrg-bbs-signatures.html#name-octets-to-proof
   octets_to_proof(proof_octets: Uint8Array): BBSProof {
-    const proof_len_floor = 2 * this.cs.octet_point_length + 4 * this.cs.octet_scalar_length;
-    if (proof_octets.length < proof_len_floor) {
+    const proof_len_floor = 3 * this.cs.octet_point_length + 4 * this.cs.octet_scalar_length;
+    if (proof_octets.length < proof_len_floor ||
+      (proof_octets.length - proof_len_floor) % this.cs.octet_scalar_length !== 0) {
       throw "invalid proof (length)";
     }
 
     let index = 0;
-    const Abar = G1Point.fromOctets(proof_octets.slice(index, index + this.cs.octet_point_length));
-    index += this.cs.octet_point_length;
-    const Bbar = G1Point.fromOctets(proof_octets.slice(index, index + this.cs.octet_point_length));
-    index += this.cs.octet_point_length;
-    const D = G1Point.fromOctets(proof_octets.slice(index, index + this.cs.octet_point_length));
-    index += this.cs.octet_point_length;
+    const points: G1Point[] = [];
+    for (let k = 0; k < 3; k++) {
+      const point = G1Point.fromOctets(proof_octets.slice(index, index + this.cs.octet_point_length));
+      if (point.equals(G1Point.Identity)) {
+        throw "invalid proof (identity point)";
+      }
+      points.push(point);
+      index += this.cs.octet_point_length;
+    }
+    const [Abar, Bbar, D] = points;
 
     const eHat = utils.os2ip(proof_octets.slice(index, index + this.cs.octet_scalar_length), true);
     index += this.cs.octet_scalar_length;

--- a/src/math.ts
+++ b/src/math.ts
@@ -14,6 +14,28 @@ type Fp2 = { c0: bigint; c1: bigint };
 type Fp6 = { c0: Fp2; c1: Fp2; c2: Fp2 };
 type Fp12 = { c0: Fp6; c1: Fp6 };
 
+// Validates the C_bit/I_bit/S_bit metadata byte of a serialized point, per
+// https://identity.foundation/bbs-signature/draft-irtf-cfrg-bbs-signatures.html#name-point-de-serialization
+// The bls library doesn't check the C_bit of E1 points, nor that an encoding
+// flagged with I_bit is the all-zeros string; without these checks, clearing
+// the C_bit of a signature or proof yields a second, distinct, valid encoding.
+function checkPointOctets(bytes: Uint8Array, expected_length: number): void {
+    if (bytes.length !== expected_length) {
+        throw new Error("invalid point length");
+    }
+    const m_byte = bytes[0] & 0xe0;
+    if (m_byte === 0x20 || m_byte === 0x60 || m_byte === 0xe0) {
+        throw new Error("invalid point encoding flag");
+    }
+    if ((m_byte & 0x80) === 0) {
+        throw new Error("invalid point encoding: only compressed points are supported");
+    }
+    if ((m_byte & 0x40) !== 0 && bytes.some((b, i) => b !== (i === 0 ? 0xc0 : 0))) {
+        // I_bit is set, so the encoding must be the identity point
+        throw new Error("invalid identity point encoding");
+    }
+}
+
 // abstract point class
 export class Point<T, U extends Point<T, U>> {
     point: ProjPointType<T>;
@@ -44,6 +66,7 @@ export class G1Point extends Point<Fp, G1Point> {
     }
     static Identity = new G1Point(bls.G1.ProjectivePoint.ZERO);
     static fromOctets(bytes: Uint8Array): G1Point {
+        checkPointOctets(bytes, 48);
         return new G1Point(bls.G1.ProjectivePoint.fromHex(bytes)); // fromHex takes bytes...
     }
     static async hashToCurve(msg: Uint8Array, dst: string): Promise<G1Point> {
@@ -69,6 +92,7 @@ export class G2Point extends Point<Fp2, G2Point> {
     static fromOctets(bytes: Uint8Array, subgroupCheck = false): G2Point {
         // note: we ignore the subgroupCheck parameter, because the bls library fromHex function
         // always checks the subgroup membership
+        checkPointOctets(bytes, 96);
         return new G2Point(bls.G2.ProjectivePoint.fromHex(bytes)); // fromHex takes bytes...
     }
 }
@@ -110,8 +134,14 @@ export class FrScalar {
     equals(s: FrScalar): boolean {
         return this.scalar === s.scalar;
     }
-    static create(scalar: bigint, nonZero: boolean = false) {
-        if (nonZero && scalar === 0n) throw new Error("scalar is 0");
+    // when canonical is set, the value MUST already be a scalar in the range [1, r-1];
+    // deserialization operations require this (e.g., octets_to_signature step 11), since
+    // silently reducing mod r would make s and s + r two valid encodings of the same value.
+    // Otherwise the value is reduced mod r (used when deriving scalars from uniform bytes).
+    static create(scalar: bigint, canonical: boolean = false) {
+        if (canonical && (scalar <= 0n || scalar >= FrScalar.blsFr.ORDER)) {
+            throw new Error("scalar is not in the range [1, r-1]");
+        }
         return new FrScalar(FrScalar.blsFr.create(scalar));
     }
 

--- a/src/math.ts
+++ b/src/math.ts
@@ -142,7 +142,7 @@ export class FrScalar {
         if (canonical && (scalar <= 0n || scalar >= FrScalar.blsFr.ORDER)) {
             throw new Error("scalar is not in the range [1, r-1]");
         }
-        return new FrScalar(FrScalar.blsFr.create(scalar));
+        return new FrScalar(scalar);
     }
 
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,8 +8,9 @@ import {sha256} from '@noble/hashes/sha256';
 import {shake256} from '@noble/hashes/sha3';
 
 // Octet Stream to Integer
-export function os2ip(bytes: Uint8Array, nonZero: boolean = false): FrScalar {
-  return FrScalar.create(utils.bytesToNumberBE(bytes), nonZero);
+// see FrScalar.create for the meaning of canonical
+export function os2ip(bytes: Uint8Array, canonical: boolean = false): FrScalar {
+  return FrScalar.create(utils.bytesToNumberBE(bytes), canonical);
 }
 
 // Integer to Octet Stream

--- a/tests/serialization.test.ts
+++ b/tests/serialization.test.ts
@@ -1,0 +1,154 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// Deserialization must reject non-canonical encodings, otherwise a single
+// signature or proof has several distinct valid encodings.
+
+import { BBS } from '../src/bbs';
+import * as crypto from 'crypto';
+import * as utils from '../src/utils';
+import { FrScalar } from '../src/math';
+import { BLS12_381_SHA256_Ciphersuite, BLS12_381_SHAKE_256_Ciphersuite } from '../src/ciphersuite';
+
+const ciphersuites = [BLS12_381_SHAKE_256_Ciphersuite, BLS12_381_SHA256_Ciphersuite];
+
+// returns a copy of octets with the metadata byte of the point starting at offset
+// replaced by m_byte (the three most significant bits of the first octet)
+function setPointFlags(octets: Uint8Array, offset: number, m_byte: number): Uint8Array {
+    const result = new Uint8Array(octets);
+    result[offset] = (result[offset] & 0x1f) | m_byte;
+    return result;
+}
+
+// returns a copy of octets with r added to the scalar starting at offset; the
+// result is a different octet string encoding the same value modulo r
+function addOrderToScalar(octets: Uint8Array, offset: number, length: number): Uint8Array {
+    const scalar = utils.os2ip(octets.slice(offset, offset + length)).scalar;
+    const shifted = scalar + FrScalar.blsFr.ORDER;
+    return utils.concat(
+        octets.slice(0, offset),
+        utils.i2osp(shifted, length),
+        octets.slice(offset + length));
+}
+
+ciphersuites.forEach(cs => {
+    describe("Deserialization tests: " + cs.ciphersuite_id, () => {
+        const bbs = new BBS(cs);
+        const header = Buffer.from("HEADER", "utf-8");
+        const ph = Buffer.from("PRESENTATION HEADER", "utf-8");
+        const L = 3;
+        const disclosed_indexes = [0, 2];
+
+        let signature: Uint8Array;
+        let proof: Uint8Array;
+
+        beforeAll(async () => {
+            const SK = bbs.KeyGen(crypto.randomBytes(32));
+            const PK = bbs.SkToPk(SK);
+            const generators = await bbs.create_generators(L);
+            const msg = Array(L).fill(null).map(() => bbs.MapMessageToScalarAsHash(crypto.randomBytes(20)));
+
+            signature = bbs.Sign(SK, PK, header, msg, generators);
+            bbs.Verify(PK, signature, header, msg, generators);
+
+            proof = bbs.ProofGen(PK, signature, header, ph, msg, generators, disclosed_indexes);
+            bbs.ProofVerify(PK, proof, header, ph, utils.filterDisclosedMessages(msg, disclosed_indexes), generators, disclosed_indexes);
+        });
+
+        // Appendix B.2.1: points are always serialized compressed, so C_bit is always 1
+        test("signatures are serialized with the C_bit set", () => {
+            expect(signature[0] & 0x80).toBe(0x80);
+            for (let k = 0; k < 3; k++) {
+                expect(proof[k * cs.octet_point_length] & 0x80).toBe(0x80);
+            }
+        });
+
+        // Appendix B.2.2: "If C_bit is 0 return INVALID and abort the operation".
+        // Without this check, clearing that one bit yields a second, different
+        // signature that still verifies.
+        test("clearing the C_bit of A must not yield a second valid signature", () => {
+            const mangled = setPointFlags(signature, 0, 0x00);
+            expect(mangled).not.toEqual(signature);
+            expect(() => bbs.octets_to_signature(mangled)).toThrow();
+        });
+
+        test("clearing the C_bit of a proof point must not yield a second valid proof", () => {
+            for (let k = 0; k < 3; k++) {
+                const mangled = setPointFlags(proof, k * cs.octet_point_length, 0x00);
+                expect(mangled).not.toEqual(proof);
+                expect(() => bbs.octets_to_proof(mangled)).toThrow();
+            }
+        });
+
+        // Appendix B.2.2: "If m_byte equals 0x20 or 0x60 or 0xE0, output INVALID"
+        [0x20, 0x60, 0xe0].forEach(m_byte => {
+            test("m_byte 0x" + m_byte.toString(16) + " must be rejected", () => {
+                expect(() => bbs.octets_to_signature(setPointFlags(signature, 0, m_byte))).toThrow();
+                expect(() => bbs.octets_to_proof(setPointFlags(proof, 0, m_byte))).toThrow();
+            });
+        });
+
+        // Appendix B.2.2 step 3: when I_bit is set, the encoding must be the all
+        // zeros string; 0x40 additionally has C_bit unset
+        [0x40, 0xc0].forEach(m_byte => {
+            test("m_byte 0x" + m_byte.toString(16) + " over a non-zero x must be rejected", () => {
+                expect(() => bbs.octets_to_signature(setPointFlags(signature, 0, m_byte))).toThrow();
+                expect(() => bbs.octets_to_proof(setPointFlags(proof, 0, m_byte))).toThrow();
+            });
+        });
+
+        // octets_to_signature step 6 and octets_to_proof step 7: the identity point
+        // is not an acceptable value, even when canonically encoded
+        test("the identity point must be rejected", () => {
+            const identity = utils.concat(new Uint8Array([0xc0]), new Uint8Array(cs.octet_point_length - 1));
+            expect(() => bbs.octets_to_signature(
+                utils.concat(identity, signature.slice(cs.octet_point_length)))).toThrow();
+            for (let k = 0; k < 3; k++) {
+                const offset = k * cs.octet_point_length;
+                expect(() => bbs.octets_to_proof(utils.concat(
+                    proof.slice(0, offset),
+                    identity,
+                    proof.slice(offset + cs.octet_point_length)))).toThrow();
+            }
+        });
+
+        // octets_to_signature step 11: "if e = 0 or e >= r, return INVALID".
+        // e and e + r both fit in octet_scalar_length octets, so silently reducing
+        // mod r would again yield a second valid signature.
+        test("a signature with e >= r must be rejected", () => {
+            const mangled = addOrderToScalar(signature, cs.octet_point_length, cs.octet_scalar_length);
+            expect(mangled).not.toEqual(signature);
+            expect(mangled.length).toBe(signature.length);
+            expect(() => bbs.octets_to_signature(mangled)).toThrow();
+        });
+
+        // octets_to_proof step 14: "if s_j = 0 or if s_j >= r, return INVALID"
+        test("a proof with a scalar >= r must be rejected", () => {
+            const scalar_count = (proof.length - 3 * cs.octet_point_length) / cs.octet_scalar_length;
+            for (let k = 0; k < scalar_count; k++) {
+                const offset = 3 * cs.octet_point_length + k * cs.octet_scalar_length;
+                const mangled = addOrderToScalar(proof, offset, cs.octet_scalar_length);
+                expect(mangled).not.toEqual(proof);
+                expect(() => bbs.octets_to_proof(mangled)).toThrow();
+            }
+        });
+
+        // octets_to_proof steps 1, 2 and 17
+        test("a proof whose length is not a valid proof length must be rejected", () => {
+            expect(() => bbs.octets_to_proof(proof.slice(0, proof.length - 1))).toThrow();
+            expect(() => bbs.octets_to_proof(utils.concat(proof, new Uint8Array(1)))).toThrow();
+            expect(() => bbs.octets_to_proof(proof.slice(0, 3 * cs.octet_point_length + 3 * cs.octet_scalar_length))).toThrow();
+        });
+
+        test("a signature whose length is wrong must be rejected", () => {
+            expect(() => bbs.octets_to_signature(signature.slice(0, signature.length - 1))).toThrow();
+            expect(() => bbs.octets_to_signature(utils.concat(signature, new Uint8Array(1)))).toThrow();
+        });
+
+        // the round trip of a well-formed value must still work
+        test("valid signatures and proofs still deserialize", () => {
+            expect(() => bbs.octets_to_signature(signature)).not.toThrow();
+            expect(() => bbs.octets_to_proof(proof)).not.toThrow();
+        });
+    });
+});


### PR DESCRIPTION
octets_to_signature and octets_to_proof accepted several distinct octet strings for the same signature or proof, so a single valid signature could be turned into a second, different one that also verifies.

Point encodings (Appendix B.2.2). The C_bit was never checked: @noble/curves 1.2.0 masks off the three metadata bits of an E1 point without inspecting them, so clearing the C_bit of A yielded a second valid signature. The same applies to Abar, Bbar and D in a proof. Validate the metadata byte in G1Point.fromOctets and G2Point.fromOctets: reject m_byte 0x20, 0x60 and 0xE0, reject C_bit == 0, and require an I_bit encoding to be the all zeros string. noble fixed the underlying parser in 1.3.0, but the check is kept here so the requirement is explicit and does not depend on the library version. G2 was never affected.

Scalars (octets_to_signature step 11, octets_to_proof step 14). FrScalar reduced its input mod r, so e and e + r were both accepted and both fit in octet_scalar_length octets, giving the same second-signature outcome through a different route. FrScalar.create now rejects anything outside [1, r-1] when deserializing; the reducing behaviour is kept for hash_to_scalar and calculate_random_scalars, which need it.

octets_to_proof also had proof_len_floor at 2 * octet_point_length instead of 3, did not check that the remaining octets are a whole number of scalars (step 17), and did not reject Abar, Bbar or D being the identity (step 7).

Add tests/serialization.test.ts covering each case over both ciphersuites. All 22 relevant assertions fail without this change.

The C_bit issue was reported by Michele Orru (@mmaker), along with a test case that this file's first two cases are based on.